### PR TITLE
Fix: use lockfile v2

### DIFF
--- a/language-server/package-lock.json
+++ b/language-server/package-lock.json
@@ -1,7 +1,7 @@
 {
 	"name": "sublime-astro",
 	"version": "1.0.0",
-	"lockfileVersion": 3,
+	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
@@ -976,6 +976,652 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">= 14"
+			}
+		}
+	},
+	"dependencies": {
+		"@astrojs/compiler": {
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.0.tgz",
+			"integrity": "sha512-7bCjW6tVDpUurQLeKBUN9tZ5kSv5qYrGmcn0sG0IwacL7isR2ZbyyA3AdZ4uxsuUFOS2SlgReTH7wkxO6zpqWA=="
+		},
+		"@astrojs/language-server": {
+			"version": "2.15.4",
+			"resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.15.4.tgz",
+			"integrity": "sha512-JivzASqTPR2bao9BWsSc/woPHH7OGSGc9aMxXL4U6egVTqBycB3ZHdBJPuOCVtcGLrzdWTosAqVPz1BVoxE0+A==",
+			"requires": {
+				"@astrojs/compiler": "^2.10.3",
+				"@astrojs/yaml2ts": "^0.2.2",
+				"@jridgewell/sourcemap-codec": "^1.4.15",
+				"@volar/kit": "~2.4.7",
+				"@volar/language-core": "~2.4.7",
+				"@volar/language-server": "~2.4.7",
+				"@volar/language-service": "~2.4.7",
+				"fast-glob": "^3.2.12",
+				"muggle-string": "^0.4.1",
+				"volar-service-css": "0.0.62",
+				"volar-service-emmet": "0.0.62",
+				"volar-service-html": "0.0.62",
+				"volar-service-prettier": "0.0.62",
+				"volar-service-typescript": "0.0.62",
+				"volar-service-typescript-twoslash-queries": "0.0.62",
+				"volar-service-yaml": "0.0.62",
+				"vscode-html-languageservice": "^5.2.0",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"@astrojs/yaml2ts": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.2.tgz",
+			"integrity": "sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ==",
+			"requires": {
+				"yaml": "^2.5.0"
+			}
+		},
+		"@emmetio/abbreviation": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+			"integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+			"requires": {
+				"@emmetio/scanner": "^1.0.4"
+			}
+		},
+		"@emmetio/css-abbreviation": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+			"integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+			"requires": {
+				"@emmetio/scanner": "^1.0.4"
+			}
+		},
+		"@emmetio/css-parser": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.0.tgz",
+			"integrity": "sha512-z7wkxRSZgrQHXVzObGkXG+Vmj3uRlpM11oCZ9pbaz0nFejvCDmAiNDpY75+wgXOcffKpj4rzGtwGaZxfJKsJxw==",
+			"requires": {
+				"@emmetio/stream-reader": "^2.2.0",
+				"@emmetio/stream-reader-utils": "^0.1.0"
+			}
+		},
+		"@emmetio/html-matcher": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+			"integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+			"requires": {
+				"@emmetio/scanner": "^1.0.0"
+			}
+		},
+		"@emmetio/scanner": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+			"integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA=="
+		},
+		"@emmetio/stream-reader": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+			"integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw=="
+		},
+		"@emmetio/stream-reader-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+			"integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A=="
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+		},
+		"@nodelib/fs.scandir": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+			"requires": {
+				"@nodelib/fs.stat": "2.0.5",
+				"run-parallel": "^1.1.9"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+		},
+		"@nodelib/fs.walk": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+			"requires": {
+				"@nodelib/fs.scandir": "2.1.5",
+				"fastq": "^1.6.0"
+			}
+		},
+		"@volar/kit": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.14.tgz",
+			"integrity": "sha512-kBcmHjEodtmYGJELHePZd2JdeYm4ZGOd9F/pQ1YETYIzAwy4Z491EkJ1nRSo/GTxwKt0XYwYA/dHSEgXecVHRA==",
+			"requires": {
+				"@volar/language-service": "2.4.14",
+				"@volar/typescript": "2.4.14",
+				"typesafe-path": "^0.2.2",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"@volar/language-core": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.14.tgz",
+			"integrity": "sha512-X6beusV0DvuVseaOEy7GoagS4rYHgDHnTrdOj5jeUb49fW5ceQyP9Ej5rBhqgz2wJggl+2fDbbojq1XKaxDi6w==",
+			"requires": {
+				"@volar/source-map": "2.4.14"
+			}
+		},
+		"@volar/language-server": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.14.tgz",
+			"integrity": "sha512-P3mGbQbW0v40UYBnb3DAaNtRYx6/MGOVKzdOWmBCGwjUkCR2xBkGrCFt05XnPDwFS/cTWDh2U6Mc9lpZ8Aecfw==",
+			"requires": {
+				"@volar/language-core": "2.4.14",
+				"@volar/language-service": "2.4.14",
+				"@volar/typescript": "2.4.14",
+				"path-browserify": "^1.0.1",
+				"request-light": "^0.7.0",
+				"vscode-languageserver": "^9.0.1",
+				"vscode-languageserver-protocol": "^3.17.5",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"@volar/language-service": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.14.tgz",
+			"integrity": "sha512-vNC3823EJohdzLTyjZoCMPwoWCfINB5emusniCkW5CGoGHQov4VVmT6yI5ncgP/NpgAIUv2NEkJooXvLHA4VeQ==",
+			"requires": {
+				"@volar/language-core": "2.4.14",
+				"vscode-languageserver-protocol": "^3.17.5",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"@volar/source-map": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.14.tgz",
+			"integrity": "sha512-5TeKKMh7Sfxo8021cJfmBzcjfY1SsXsPMMjMvjY7ivesdnybqqS+GxGAoXHAOUawQTwtdUxgP65Im+dEmvWtYQ=="
+		},
+		"@volar/typescript": {
+			"version": "2.4.14",
+			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.14.tgz",
+			"integrity": "sha512-p8Z6f/bZM3/HyCdRNFZOEEzts51uV8WHeN8Tnfnm2EBv6FDB2TQLzfVx7aJvnl8ofKAOnS64B2O8bImBFaauRw==",
+			"requires": {
+				"@volar/language-core": "2.4.14",
+				"path-browserify": "^1.0.1",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"@vscode/emmet-helper": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+			"integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+			"requires": {
+				"emmet": "^2.4.3",
+				"jsonc-parser": "^2.3.0",
+				"vscode-languageserver-textdocument": "^1.0.1",
+				"vscode-languageserver-types": "^3.15.1",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"@vscode/l10n": {
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+			"integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ=="
+		},
+		"ajv": {
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"requires": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			}
+		},
+		"braces": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+			"requires": {
+				"fill-range": "^7.1.1"
+			}
+		},
+		"emmet": {
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+			"integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+			"requires": {
+				"@emmetio/abbreviation": "^2.3.3",
+				"@emmetio/css-abbreviation": "^2.1.8"
+			}
+		},
+		"fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+		},
+		"fast-glob": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+			"requires": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.2",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.8"
+			}
+		},
+		"fast-uri": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+			"integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="
+		},
+		"fastq": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+			"integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+			"requires": {
+				"reusify": "^1.0.4"
+			}
+		},
+		"fill-range": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+			"requires": {
+				"to-regex-range": "^5.0.1"
+			}
+		},
+		"glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"requires": {
+				"is-glob": "^4.0.1"
+			}
+		},
+		"is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+		},
+		"is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"requires": {
+				"is-extglob": "^2.1.1"
+			}
+		},
+		"is-number": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+		},
+		"json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+		},
+		"jsonc-parser": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+			"integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="
+		},
+		"lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
+		"merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+		},
+		"micromatch": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+			"requires": {
+				"braces": "^3.0.3",
+				"picomatch": "^2.3.1"
+			}
+		},
+		"muggle-string": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+			"integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="
+		},
+		"path-browserify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+		},
+		"picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+		},
+		"prettier": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ=="
+		},
+		"prettier-plugin-astro": {
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
+			"integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
+			"requires": {
+				"@astrojs/compiler": "^2.9.1",
+				"prettier": "^3.0.0",
+				"sass-formatter": "^0.7.6"
+			}
+		},
+		"queue-microtask": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+		},
+		"request-light": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+			"integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q=="
+		},
+		"require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+		},
+		"reusify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+			"integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="
+		},
+		"run-parallel": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+			"requires": {
+				"queue-microtask": "^1.2.2"
+			}
+		},
+		"s.color": {
+			"version": "0.0.15",
+			"resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+			"integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA=="
+		},
+		"sass-formatter": {
+			"version": "0.7.9",
+			"resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
+			"integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
+			"requires": {
+				"suf-log": "^2.5.3"
+			}
+		},
+		"semver": {
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="
+		},
+		"suf-log": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+			"integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+			"requires": {
+				"s.color": "0.0.15"
+			}
+		},
+		"to-regex-range": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+			"requires": {
+				"is-number": "^7.0.0"
+			}
+		},
+		"typesafe-path": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+			"integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="
+		},
+		"typescript": {
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="
+		},
+		"typescript-auto-import-cache": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+			"integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+			"requires": {
+				"semver": "^7.3.8"
+			}
+		},
+		"volar-service-css": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.62.tgz",
+			"integrity": "sha512-JwNyKsH3F8PuzZYuqPf+2e+4CTU8YoyUHEHVnoXNlrLe7wy9U3biomZ56llN69Ris7TTy/+DEX41yVxQpM4qvg==",
+			"requires": {
+				"vscode-css-languageservice": "^6.3.0",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"volar-service-emmet": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.62.tgz",
+			"integrity": "sha512-U4dxWDBWz7Pi4plpbXf4J4Z/ss6kBO3TYrACxWNsE29abu75QzVS0paxDDhI6bhqpbDFXlpsDhZ9aXVFpnfGRQ==",
+			"requires": {
+				"@emmetio/css-parser": "^0.4.0",
+				"@emmetio/html-matcher": "^1.3.0",
+				"@vscode/emmet-helper": "^2.9.3",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"volar-service-html": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.62.tgz",
+			"integrity": "sha512-Zw01aJsZRh4GTGUjveyfEzEqpULQUdQH79KNEiKVYHZyuGtdBRYCHlrus1sueSNMxwwkuF5WnOHfvBzafs8yyQ==",
+			"requires": {
+				"vscode-html-languageservice": "^5.3.0",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"volar-service-prettier": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.62.tgz",
+			"integrity": "sha512-h2yk1RqRTE+vkYZaI9KYuwpDfOQRrTEMvoHol0yW4GFKc75wWQRrb5n/5abDrzMPrkQbSip8JH2AXbvrRtYh4w==",
+			"requires": {
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"volar-service-typescript": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.62.tgz",
+			"integrity": "sha512-p7MPi71q7KOsH0eAbZwPBiKPp9B2+qrdHAd6VY5oTo9BUXatsOAdakTm9Yf0DUj6uWBAaOT01BSeVOPwucMV1g==",
+			"requires": {
+				"path-browserify": "^1.0.1",
+				"semver": "^7.6.2",
+				"typescript-auto-import-cache": "^0.3.3",
+				"vscode-languageserver-textdocument": "^1.0.11",
+				"vscode-nls": "^5.2.0",
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"volar-service-typescript-twoslash-queries": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.62.tgz",
+			"integrity": "sha512-KxFt4zydyJYYI0kFAcWPTh4u0Ha36TASPZkAnNY784GtgajerUqM80nX/W1d0wVhmcOFfAxkVsf/Ed+tiYU7ng==",
+			"requires": {
+				"vscode-uri": "^3.0.8"
+			}
+		},
+		"volar-service-yaml": {
+			"version": "0.0.62",
+			"resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.62.tgz",
+			"integrity": "sha512-k7gvv7sk3wa+nGll3MaSKyjwQsJjIGCHFjVkl3wjaSP2nouKyn9aokGmqjrl39mi88Oy49giog2GkZH526wjig==",
+			"requires": {
+				"vscode-uri": "^3.0.8",
+				"yaml-language-server": "~1.15.0"
+			}
+		},
+		"vscode-css-languageservice": {
+			"version": "6.3.5",
+			"resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.5.tgz",
+			"integrity": "sha512-ehEIMXYPYEz/5Svi2raL9OKLpBt5dSAdoCFoLpo0TVFKrVpDemyuQwS3c3D552z/qQCg3pMp8oOLMObY6M3ajQ==",
+			"requires": {
+				"@vscode/l10n": "^0.0.18",
+				"vscode-languageserver-textdocument": "^1.0.12",
+				"vscode-languageserver-types": "3.17.5",
+				"vscode-uri": "^3.1.0"
+			}
+		},
+		"vscode-html-languageservice": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.4.0.tgz",
+			"integrity": "sha512-9/cbc90BSYCghmHI7/VbWettHZdC7WYpz2g5gBK6UDUI1MkZbM773Q12uAYJx9jzAiNHPpyo6KzcwmcnugncAQ==",
+			"requires": {
+				"@vscode/l10n": "^0.0.18",
+				"vscode-languageserver-textdocument": "^1.0.12",
+				"vscode-languageserver-types": "^3.17.5",
+				"vscode-uri": "^3.1.0"
+			}
+		},
+		"vscode-json-languageservice": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+			"integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+			"requires": {
+				"jsonc-parser": "^3.0.0",
+				"vscode-languageserver-textdocument": "^1.0.1",
+				"vscode-languageserver-types": "^3.16.0",
+				"vscode-nls": "^5.0.0",
+				"vscode-uri": "^3.0.2"
+			},
+			"dependencies": {
+				"jsonc-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+					"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
+				}
+			}
+		},
+		"vscode-jsonrpc": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="
+		},
+		"vscode-languageserver": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+			"requires": {
+				"vscode-languageserver-protocol": "3.17.5"
+			}
+		},
+		"vscode-languageserver-protocol": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"requires": {
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
+			}
+		},
+		"vscode-languageserver-textdocument": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
+		},
+		"vscode-languageserver-types": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+		},
+		"vscode-nls": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+			"integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng=="
+		},
+		"vscode-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="
+		},
+		"yaml": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ=="
+		},
+		"yaml-language-server": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.15.0.tgz",
+			"integrity": "sha512-N47AqBDCMQmh6mBLmI6oqxryHRzi33aPFPsJhYy3VTUGCdLHYjGh4FZzpUjRlphaADBBkDmnkM/++KNIOHi5Rw==",
+			"requires": {
+				"ajv": "^8.11.0",
+				"lodash": "4.17.21",
+				"prettier": "2.8.7",
+				"request-light": "^0.5.7",
+				"vscode-json-languageservice": "4.1.8",
+				"vscode-languageserver": "^7.0.0",
+				"vscode-languageserver-textdocument": "^1.0.1",
+				"vscode-languageserver-types": "^3.16.0",
+				"vscode-nls": "^5.0.0",
+				"vscode-uri": "^3.0.2",
+				"yaml": "2.2.2"
+			},
+			"dependencies": {
+				"prettier": {
+					"version": "2.8.7",
+					"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+					"integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+					"optional": true
+				},
+				"request-light": {
+					"version": "0.5.8",
+					"resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+					"integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="
+				},
+				"vscode-jsonrpc": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+					"integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+				},
+				"vscode-languageserver": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+					"integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
+					"requires": {
+						"vscode-languageserver-protocol": "3.16.0"
+					}
+				},
+				"vscode-languageserver-protocol": {
+					"version": "3.16.0",
+					"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+					"integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+					"requires": {
+						"vscode-jsonrpc": "6.0.0",
+						"vscode-languageserver-types": "3.16.0"
+					}
+				},
+				"vscode-languageserver-types": {
+					"version": "3.16.0",
+					"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+					"integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+				},
+				"yaml": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+					"integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA=="
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Yarn fails to install dependencies when using `"lockfileVersion": 3`
Same issue and fix as https://github.com/sublimelsp/LSP-svelte/pull/157