### PR TITLE
refactor: add ruff rules for sorting imports

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
-from pathlib import Path, WindowsPath
-from typing import TYPE_CHECKING
 
 from lsp_utils import NpmClientHandler
+from pathlib import Path
+from pathlib import WindowsPath
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from LSP.plugin import ClientConfig
     from LSP.plugin import WorkspaceFolder
-    from sublime import Window, View
+    from sublime import View
+    from sublime import Window
 
 __all__ = ["LspAstroPlugin", "plugin_loaded", "plugin_unloaded"]
 

--- a/plugin.py
+++ b/plugin.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from lsp_utils import NpmClientHandler
-from pathlib import Path
-from pathlib import WindowsPath
+from pathlib import Path, WindowsPath
 from typing import TYPE_CHECKING
 
+from lsp_utils import NpmClientHandler
+
 if TYPE_CHECKING:
-    from LSP.plugin import ClientConfig
-    from LSP.plugin import WorkspaceFolder
-    from sublime import View
-    from sublime import Window
+    from LSP.plugin import ClientConfig, WorkspaceFolder
+    from sublime import View, Window
 
 __all__ = ["LspAstroPlugin", "plugin_loaded", "plugin_unloaded"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-
 [tool.pyright]
 pythonVersion = "3.8"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,7 @@ preview = true
 select = ["F401", "I"]
 
 [tool.ruff.lint.isort]
-case-sensitive = false
-force-single-line = true
-from-first = true
-no-sections = true
+case-sensitive = true
+combine-as-imports = true
 order-by-type = false
 required-imports = ["from __future__ import annotations"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,20 @@
-[tool.black]
-line-length = 100
-target-version = ['py38']
 
-# regex
-exclude = '''
-/(
-  \.git |
-  \.github |
-  language-server |
-)/
-'''
+[tool.pyright]
+pythonVersion = "3.8"
+
+[tool.ruff]
+line-length = 120
+target-version = "py38"
+
+[tool.ruff.lint]
+# Enable preview rules.
+preview = true
+select = ["F401", "I"]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+from-first = true
+no-sections = true
+order-by-type = false
+required-imports = ["from __future__ import annotations"]


### PR DESCRIPTION
This is a semi-automatically created PR that adds ruff configuration for imports formatting.

It matches configuration included in the LSP package with the intention of consolidating import style across all LSP packages.

If you have strong preference to a different style, please keep the configuration but update it to your liking so that anyone working on the package does not have to guess the correct style to use. See [ruff isort settings](https://docs.astral.sh/ruff/settings/#lintisort).

(Since this PR was created semi-automatically, it might require some changes before being considered ready.)